### PR TITLE
NN speedups

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.5.3"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
 Lux = "b2108857-7c20-44ae-9111-449ecde12c47"
 NetCDF = "30363a11-5582-574a-97bb-aa9a979735b9"

--- a/src/preallocate.jl
+++ b/src/preallocate.jl
@@ -656,7 +656,7 @@ function NNVars{T}(G::Grid) where {T<:AbstractFloat}
     d_corner_res = Reactant.to_rarray(Array{T}(undef, 2, nqx, nqy))
     d_center_res = Reactant.to_rarray(Array{T}(undef, 1, nx, ny))
 
-    use_reactant = true
+    use_reactant = false
 
     if use_reactant
         model_corner = Reactant.to_rarray(model_corner)


### PR DESCRIPTION
Added rules for reactant to differentiate the NN, general speedups throughout code, currently runs the primal fast and the NN fast _and_ the differentiation of ShallowWaters with the integrated NN does not take a long time (still slower, but not so slow that experiments can't be done). There does seem to be a difference between the result with Checkpointing and the result with Checkpointing + Enzyme